### PR TITLE
Add boombox-auto

### DIFF
--- a/packages/boombox-admin/Clarinet.toml
+++ b/packages/boombox-admin/Clarinet.toml
@@ -3,6 +3,9 @@
 name = "boom.money"
 
 
+[[project.requirements]]
+contract_id = "SP3C0TCQS0C0YY8E0V3EJ7V4X9571885D44M8EFWF.arkadiko-automation-trait-v1"
+
 [contracts.boombox-admin]
 path = "contracts/boombox-admin.clar"
 depends_on = ["boombox-trait"]
@@ -15,5 +18,8 @@ depends_on = []
 path = "contracts/boombox-simple.clar"
 depends_on = []
 
+[contracts.boombox-auto]
+path = "contracts/boombox-auto.clar"
+depends_on = []
 
 [notebooks]

--- a/packages/boombox-admin/contracts/boombox-auto.clar
+++ b/packages/boombox-admin/contracts/boombox-auto.clar
@@ -1,0 +1,22 @@
+;; finalize boombox 100 blocks before end of every stacking cycle
+(impl-trait 'SP3C0TCQS0C0YY8E0V3EJ7V4X9571885D44M8EFWF.arkadiko-automation-trait-v1.automation-trait)
+
+(define-constant pox-addr {version: 0x01, hashbytes: 0x13effebe0ea4bb45e35694f5a15bb5b96e851afb})
+(define-map commits uint uint)
+
+(define-public (initialize)
+  (ok true)
+)
+
+(define-read-only (check-job)
+  (let ((reward-cycle (contract-call? .boombox-admin current-cycle))
+        (start-of-cycle (contract-call? .boombox-admin reward-cycle-to-burn-height reward-cycle)))
+    (asserts! (> burn-block-height (+ u2000 start-of-cycle)) (ok false))
+    (asserts! (is-none (map-get? commits (+ u1 reward-cycle))) (ok false))
+    (ok true)))
+
+(define-public (run-job)
+  (let ((next-cycle (+ u1 (contract-call? .boombox-admin current-cycle))))
+    (asserts! (unwrap-panic (check-job)) (ok false))
+    (map-insert commits next-cycle block-height)
+    (contract-call? .boombox-admin stack-aggregation-commit pox-addr next-cycle)))

--- a/packages/boombox-admin/contracts/boombox-auto.clar
+++ b/packages/boombox-admin/contracts/boombox-auto.clar
@@ -20,3 +20,6 @@
     (asserts! (unwrap-panic (check-job)) (ok false))
     (map-insert commits next-cycle block-height)
     (contract-call? .boombox-admin stack-aggregation-commit pox-addr next-cycle)))
+
+(define-read-only (get-commit (reward-cycle uint))
+    (map-get? commits reward-cycle))


### PR DESCRIPTION
This PR
* adds a contract that implements Arkadiko Keeper automation trait. The job would run 100 blocks before the start of the next cycle. It is configured for reward address 33WSGLeVoEpuZDjB54HKZ1y5YsERELoVNq